### PR TITLE
update to libreoffice 4.3.5, and update for new URL download URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,9 +6,9 @@
 #   class { 'libreoffice':
 #     version => '4.3.4',
 #   }
-class libreoffice($version='4.3.4') {
+class libreoffice($version='4.3.5') {
   package { "LibreOffice-${version}":
     provider => 'appdmg',
-    source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86/LibreOffice_${version}_MacOS_x86.dmg",
+    source   => "http://download.documentfoundation.org/libreoffice/stable/${version}/mac/x86_64/LibreOffice_${version}_MacOS_x86-64.dmg",
   }
 }


### PR DESCRIPTION
Download URL no longer works.  Original repo hasn't been updated in a while so created this PR in case you want to keep your repo current.
